### PR TITLE
Update href of the Proximus link in the Locations

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@
                 <div style="width:50%; float:left;">
                     <p class="date">18 — 28 July</p>
                     <p class="city">Brussels</p>
-                    <p class="city"><a href="http://www.selor.be/nl/" target="_blank" style="color:white;" >Proximus</a></p>
+                    <p class="city"><a href="http://www.proximus.be/" target="_blank" style="color:white;" >Proximus</a></p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
href was copy/pasted from the Selor link and it didn't make much sense upon clicking on it.
Don't know if you planned for another link than the main Proximus link, but at least you've been notified of it
